### PR TITLE
Configure android ocr camera dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,53 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    namespace 'com.example.handwrittenocrsumcam'
+    compileSdk 33
+
+    defaultConfig {
+        applicationId "com.example.handwrittenocrsumcam"
+        minSdk 24
+        targetSdk 33
+        versionCode 1
+        versionName "1.0"
+    }
+
+    signingConfigs {
+        release {
+            storeFile file("keystore.jks")
+            storePassword System.getenv("KEYSTORE_PASSWORD")
+            keyAlias System.getenv("KEY_ALIAS")
+            keyPassword System.getenv("KEY_PASSWORD")
+        }
+    }
+
+    buildTypes {
+        release {
+            signingConfig signingConfigs.release
+            minifyEnabled false
+        }
+        debug {
+            signingConfig signingConfigs.release
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions { jvmTarget = '1.8' }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.mlkit:text-recognition:16.1.0'
+    implementation 'androidx.camera:camera-core:1.2.0'
+    implementation 'androidx.camera:camera-camera2:1.2.0'
+    implementation 'androidx.camera:camera-lifecycle:1.2.0'
+    implementation 'androidx.camera:camera-view:1.2.0'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.0'
+}


### PR DESCRIPTION
Add `app/build.gradle` to configure the Android project for a handwritten OCR camera application.